### PR TITLE
Fix unhandled exception when decoding invalid truth payload

### DIFF
--- a/lib/captchah/verifier.rb
+++ b/lib/captchah/verifier.rb
@@ -16,7 +16,7 @@ module Captchah
       return :valid if guess == truth_payload[:truth].downcase
 
       :invalid
-    rescue ArgumentError, MessageEncryptor::InvalidMessage
+    rescue ArgumentError, ActiveSupport::MessageEncryptor::InvalidMessage
       :invalid
     end
   end


### PR DESCRIPTION
When an invalid truth payload (i.e. not base64-encoded) is provided to the verifier, the following exception is thrown:

```
uninitialized constant Captchah::Verifier::MessageEncryptor
```

The reason for this is that the exception handler has an incorrect reference to `MessageEncryptor`. The reference should include the module: ``ActiveSupport::MessageEncryptor``.